### PR TITLE
Reek compatibility patches

### DIFF
--- a/lib/metric_fu/metrics/reek/generator.rb
+++ b/lib/metric_fu/metrics/reek/generator.rb
@@ -1,4 +1,3 @@
-require "metric_fu/gem_version"
 module MetricFu
   class ReekGenerator < Generator
     def self.metric
@@ -17,15 +16,12 @@ module MetricFu
 
     def run!(files, config_files)
       require "reek"
-      version = MetricFu::GemVersion.activated_version("reek")
-      if version >= "2.2.0"
-        examiner = Reek::Core::Examiner
-      else
-        examiner = Reek::Examiner
-        if version > "1.6.0"
-          require "reek/configuration/app_configuration"
-        end
-      end
+      # To load any changing dependencies such as "reek/configuration/app_configuration"
+      #   Added in 1.6.0 https://github.com/troessner/reek/commit/7f4ed2be442ca926e08ccc41945e909e8f710947
+      #   But not always loaded
+      require "reek/cli/application"
+
+      examiner = Reek.const_defined?(:Examiner) ? Reek.const_get(:Examiner) : Reek.const_get(:Core).const_get(:Examiner)
       examiner.new(files, config_files)
     end
 

--- a/lib/metric_fu/metrics/reek/generator.rb
+++ b/lib/metric_fu/metrics/reek/generator.rb
@@ -1,3 +1,4 @@
+require "metric_fu/gem_version"
 module MetricFu
   class ReekGenerator < Generator
     def self.metric
@@ -15,14 +16,17 @@ module MetricFu
     end
 
     def run!(files, config_files)
-      require 'reek'
-      begin
-        require 'reek/configuration/app_configuration'
-      rescue LoadError
-        # nothing we can do, it's probably an older reek version which doesn't need this file
+      require "reek"
+      version = MetricFu::GemVersion.activated_version("reek")
+      if version >= "2.2.0"
+        examiner = Reek::Core::Examiner
+      else
+        examiner = Reek::Examiner
+        if version > "1.6.0"
+          require "reek/configuration/app_configuration"
+        end
       end
-
-      Reek::Examiner.new(files, config_files)
+      examiner.new(files, config_files)
     end
 
     def analyze


### PR DESCRIPTION
Ref: 
- https://github.com/troessner/reek/issues/516
- https://github.com/metricfu/metric_fu/pull/258

I ran this locally against Reek 1.3.4, 1.6.0, 2.1.0, and 2.2.1.  I don't think it's worth adding the appraisals gem just for this...
